### PR TITLE
Refactor probabilities indexing to use strings

### DIFF
--- a/classifier/naiveBayes.go
+++ b/classifier/naiveBayes.go
@@ -1,46 +1,51 @@
 package classifier
 
 type _PDhKey struct {
-	feature      uint64
-	featureValue uint64
-	class        uint64
+	feature      string
+	featureValue string
+	class        string
 }
+
+type Example map[string]string
 
 // NaiveBayes represents a Naive Bayes Classifier
 type NaiveBayes struct {
 	PDh map[_PDhKey]float64
-	Ph  []float64
+	Ph  map[string]float64
 }
 
-func (nb NaiveBayes) conditionalPriorProbability(feature uint64, featureValue uint64, class uint64) float64 {
+func (nb NaiveBayes) conditionalPriorProbability(feature string, featureValue string, class string) float64 {
 	key := _PDhKey{feature, featureValue, class}
 	return nb.PDh[key]
 }
 
-func (nb NaiveBayes) classPriorProbability(class uint64) float64 {
+func (nb NaiveBayes) classPriorProbability(class string) float64 {
 	return nb.Ph[class]
 }
 
-func (nb NaiveBayes) posterioriProbability(features []uint64, class uint64) float64 {
+func (nb NaiveBayes) posterioriProbability(example Example, class string) float64 {
+	// TODO: use logarithms to calculate probabilities
 	probability := nb.classPriorProbability(class)
-	for feature, featureValue := range features {
-		probability *= nb.conditionalPriorProbability(uint64(feature), featureValue, class)
+	for feature, featureValue := range example {
+		probability *= nb.conditionalPriorProbability(feature, featureValue, class)
 	}
 
 	return probability
 }
 
 // Predict receives an array of features and returns the predicted encoded class
-func (nb NaiveBayes) Predict(features []uint64) (uint64, float64) {
-	var maxArg uint64
+func (nb NaiveBayes) Predict(example Example) (string, float64) {
+	var maxArg string
 	var maxVal float64
+	var maxSet = false
 	var total float64
 	for class := range nb.Ph {
-		val := nb.posterioriProbability(features, uint64(class))
+		val := nb.posterioriProbability(example, class)
 		total += val
-		if val > maxVal || class == 0 {
-			maxArg = uint64(class)
+		if val > maxVal || !maxSet {
+			maxArg = class
 			maxVal = val
+			maxSet = true
 		}
 	}
 
@@ -48,16 +53,16 @@ func (nb NaiveBayes) Predict(features []uint64) (uint64, float64) {
 }
 
 // Train receives the dataset and trains the classifier
-func (nb *NaiveBayes) Train(ds [][]uint64) {
+func (nb *NaiveBayes) Train(examples []Example, classifications []string) {
 	freqTable := make(map[_PDhKey]float64)
-	countTable := make(map[uint64]float64)
+	countTable := make(map[string]float64)
 
 	// Fill the frequency table
-	for _, row := range ds {
-		class := row[len(row)-1]
+	for row, example := range examples {
+		class := classifications[row]
 		countTable[class]++
-		for feature, featureValue := range row[:len(row)-1] {
-			freqTable[_PDhKey{uint64(feature), featureValue, class}]++
+		for feature, featureValue := range example {
+			freqTable[_PDhKey{feature, featureValue, class}]++
 		}
 	}
 
@@ -70,9 +75,9 @@ func (nb *NaiveBayes) Train(ds [][]uint64) {
 }
 
 // NewNaiveBayes creates a new Naive Bayes Classifier
-func NewNaiveBayes(probH []float64) NaiveBayes {
+func NewNaiveBayes(priorClassProbabilities map[string]float64) NaiveBayes {
 	nb := NaiveBayes{}
-	nb.Ph = probH
+	nb.Ph = priorClassProbabilities
 
 	return nb
 }


### PR DESCRIPTION
## Summary

- Probabilities are now indexed using strings

## Notes
The dataset must be converted to:
  - list of `classifier.Example` for explained variables
  - list of strings for the classification of each example

A classifier.Example is just a map[string]string where the key is the name of the field and the value is the value of the field.

The indexing of the list of strings for the classifications must match the indexing of the examples list. That means that `classifications[I]` must be the classification of `examples[I]`.